### PR TITLE
Add persistent MusicBrainz caching with queued rate limiting

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3807,6 +3807,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,3 +33,4 @@ chrono-tz = "0.8"
 regex = "1"
 sha2 = "0.10"
 dirs = "5"
+tokio = { version = "1", features = ["sync", "time"] }


### PR DESCRIPTION
## Summary
- persist MusicBrainz artist profiles in the SQLite store for reuse across sessions
- queue outbound MusicBrainz lookups and enforce a one-request-per-second rate limit
- pull in Tokio sync/time utilities to support the new asynchronous control flow

## Testing
- cargo fmt
- cargo check *(fails: system library `glib-2.0` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e34dc49a4c8326bd416ef3cc87b272