### PR TITLE
Improve navigation accessibility and responsive layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,9 +15,35 @@ body {
 }
 
 .app-shell {
+  position: relative;
   display: flex;
   min-height: 100vh;
   color: rgb(23, 37, 84);
+}
+
+.app-shell__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 16px;
+  padding: 8px 12px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  color: rgb(23, 37, 84);
+  text-decoration: none;
+  transition: top 0.2s ease;
+  z-index: 40;
+}
+
+.skip-link:focus {
+  top: 16px;
 }
 
 .app-shell__sidebar {
@@ -28,6 +54,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 32px;
+  transition: transform 0.3s ease;
+  z-index: 20;
 }
 
 .app-shell__brand {
@@ -65,6 +93,11 @@ body {
   font-size: 14px;
 }
 
+.app-shell__nav-link:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.7);
+  outline-offset: 2px;
+}
+
 .app-shell__nav-link:hover {
   background: rgba(255, 255, 255, 0.1);
   color: #fff;
@@ -79,6 +112,68 @@ body {
   flex: 1;
   padding: 32px;
   overflow-y: auto;
+}
+
+.app-shell__header {
+  display: none;
+}
+
+.app-shell__header-title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.app-shell__header-subtitle {
+  font-size: 14px;
+  color: rgba(15, 23, 42, 0.6);
+  margin-top: 4px;
+}
+
+.app-shell__menu-button {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: #fff;
+  cursor: pointer;
+  font-size: 20px;
+}
+
+.app-shell__menu-button:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.7);
+  outline-offset: 2px;
+}
+
+.app-shell__backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.app-shell__backdrop:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.7);
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .section-header {
@@ -201,6 +296,55 @@ body {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+@media (max-width: 1023px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .app-shell__sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    max-width: 280px;
+    height: 100vh;
+    overflow-y: auto;
+    transform: translateX(-100%);
+    box-shadow: 16px 0 40px rgba(15, 23, 42, 0.35);
+  }
+
+  .app-shell--sidebar-open .app-shell__sidebar {
+    transform: translateX(0);
+  }
+
+  .app-shell__main {
+    min-height: 100vh;
+    background: #f3f4f6;
+  }
+
+  .app-shell__header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px;
+    background: #fff;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    position: sticky;
+    top: 0;
+    z-index: 15;
+  }
+
+  .app-shell__menu-button {
+    display: inline-flex;
+  }
+
+  .app-shell__backdrop {
+    display: block;
+  }
+
+  .app-shell__content {
+    padding: 24px 16px 32px;
+  }
 }
 
 .form-field__label {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { NavLink, Outlet } from "react-router-dom";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 
 const NAVIGATION = [
@@ -12,18 +12,73 @@ const NAVIGATION = [
 
 export default function App() {
   const navItems = useMemo(() => NAVIGATION, []);
+  const [sidebarOpen, setSidebarOpen] = useState(() => {
+    if (typeof window === "undefined") {
+      return true;
+    }
+    return window.innerWidth >= 1024;
+  });
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === "undefined") {
+      return true;
+    }
+    return window.innerWidth >= 1024;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    function handleResize() {
+      const desktop = window.innerWidth >= 1024;
+      setIsDesktop(desktop);
+      setSidebarOpen(desktop);
+    }
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  function handleToggleSidebar() {
+    if (isDesktop) {
+      return;
+    }
+    setSidebarOpen((prev) => !prev);
+  }
+
+  function handleCloseSidebar() {
+    if (isDesktop) {
+      return;
+    }
+    setSidebarOpen(false);
+  }
 
   return (
-    <div className="app-shell">
-      <aside className="app-shell__sidebar">
+    <div className={`app-shell${sidebarOpen ? " app-shell--sidebar-open" : ""}`}>
+      <a className="skip-link" href="#main-content">
+        Skip to content
+      </a>
+      {!isDesktop && sidebarOpen && (
+        <button
+          type="button"
+          className="app-shell__backdrop"
+          aria-label="Close navigation"
+          onClick={handleCloseSidebar}
+        />
+      )}
+      <aside className="app-shell__sidebar" aria-label="Primary navigation">
         <div className="app-shell__brand">
-          <span className="app-shell__logo">🎵</span>
+          <span className="app-shell__logo" aria-hidden="true">
+            🎵
+          </span>
           <div>
             <div className="app-shell__title">ShowScraper</div>
             <div className="app-shell__subtitle">Tauri v2</div>
           </div>
         </div>
-        <nav className="app-shell__nav">
+        <nav id="primary-navigation" className="app-shell__nav">
           {navItems.map((item) => (
             <NavLink
               key={item.to}
@@ -38,9 +93,29 @@ export default function App() {
           ))}
         </nav>
       </aside>
-      <main className="app-shell__content">
-        <Outlet />
-      </main>
+      <div className="app-shell__main">
+        <header className="app-shell__header">
+          <button
+            type="button"
+            className="app-shell__menu-button"
+            onClick={handleToggleSidebar}
+            aria-controls="primary-navigation"
+            aria-expanded={sidebarOpen}
+          >
+            <span className="sr-only">Toggle navigation</span>
+            ☰
+          </button>
+          <div>
+            <div className="app-shell__header-title">ShowScraper</div>
+            <div className="app-shell__header-subtitle">
+              Monitor scraping health, posting status, and upcoming tasks.
+            </div>
+          </div>
+        </header>
+        <main id="main-content" className="app-shell__content" tabIndex={-1}>
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a responsive sidebar toggle with skip link and accessible navigation landmarks
- style the layout for mobile viewports with overlay/backdrop support and improved focus states
- introduce mobile header copy to reinforce context when the sidebar is collapsed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e436e5bec8832696c27bfe37ccba45