### PR TITLE
Add data test ids for browser automation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,8 +56,11 @@ export default function App() {
   }
 
   return (
-    <div className={`app-shell${sidebarOpen ? " app-shell--sidebar-open" : ""}`}>
-      <a className="skip-link" href="#main-content">
+    <div
+      data-testid="app-shell"
+      className={`app-shell${sidebarOpen ? " app-shell--sidebar-open" : ""}`}
+    >
+      <a data-testid="skip-to-content-link" className="skip-link" href="#main-content">
         Skip to content
       </a>
       {!isDesktop && sidebarOpen && (
@@ -66,24 +69,40 @@ export default function App() {
           className="app-shell__backdrop"
           aria-label="Close navigation"
           onClick={handleCloseSidebar}
+          data-testid="sidebar-backdrop"
         />
       )}
-      <aside className="app-shell__sidebar" aria-label="Primary navigation">
-        <div className="app-shell__brand">
-          <span className="app-shell__logo" aria-hidden="true">
+      <aside
+        className="app-shell__sidebar"
+        aria-label="Primary navigation"
+        data-testid="sidebar"
+      >
+        <div className="app-shell__brand" data-testid="app-shell-brand">
+          <span className="app-shell__logo" aria-hidden="true" data-testid="app-shell-logo">
             🎵
           </span>
-          <div>
-            <div className="app-shell__title">ShowScraper</div>
-            <div className="app-shell__subtitle">Tauri v2</div>
+          <div data-testid="app-shell-brand-text">
+            <div className="app-shell__title" data-testid="app-shell-title">
+              ShowScraper
+            </div>
+            <div className="app-shell__subtitle" data-testid="app-shell-subtitle">
+              Tauri v2
+            </div>
           </div>
         </div>
-        <nav id="primary-navigation" className="app-shell__nav">
+        <nav
+          id="primary-navigation"
+          className="app-shell__nav"
+          data-testid="primary-navigation"
+        >
           {navItems.map((item) => (
             <NavLink
               key={item.to}
               to={item.to}
               end={item.to === "/"}
+              data-testid={`nav-link-${
+                item.to === "/" ? "dashboard" : item.to.replace(/\//g, "-")
+              }`}
               className={({ isActive }) =>
                 `app-shell__nav-link${isActive ? " app-shell__nav-link--active" : ""}`
               }
@@ -93,26 +112,37 @@ export default function App() {
           ))}
         </nav>
       </aside>
-      <div className="app-shell__main">
-        <header className="app-shell__header">
+      <div className="app-shell__main" data-testid="app-shell-main">
+        <header className="app-shell__header" data-testid="app-shell-header">
           <button
             type="button"
             className="app-shell__menu-button"
             onClick={handleToggleSidebar}
             aria-controls="primary-navigation"
             aria-expanded={sidebarOpen}
+            data-testid="menu-button"
           >
             <span className="sr-only">Toggle navigation</span>
             ☰
           </button>
-          <div>
-            <div className="app-shell__header-title">ShowScraper</div>
-            <div className="app-shell__header-subtitle">
+          <div data-testid="app-shell-header-text">
+            <div className="app-shell__header-title" data-testid="app-shell-header-title">
+              ShowScraper
+            </div>
+            <div
+              className="app-shell__header-subtitle"
+              data-testid="app-shell-header-subtitle"
+            >
               Monitor scraping health, posting status, and upcoming tasks.
             </div>
           </div>
         </header>
-        <main id="main-content" className="app-shell__content" tabIndex={-1}>
+        <main
+          id="main-content"
+          className="app-shell__content"
+          tabIndex={-1}
+          data-testid="main-content"
+        >
           <Outlet />
         </main>
       </div>

--- a/src/app/routes/Dashboard.tsx
+++ b/src/app/routes/Dashboard.tsx
@@ -1,10 +1,14 @@
 export default function Dashboard() {
   return (
-    <div className="card">
-      <div className="section-header">
-        <div className="section-header__title">Dashboard</div>
+    <div className="card" data-testid="dashboard-card">
+      <div className="section-header" data-testid="dashboard-header">
+        <div className="section-header__title" data-testid="dashboard-title">
+          Dashboard
+        </div>
       </div>
-      <p>Monitor scraping health, posting status, and upcoming automation tasks here.</p>
+      <p data-testid="dashboard-description">
+        Monitor scraping health, posting status, and upcoming automation tasks here.
+      </p>
     </div>
   );
 }

--- a/src/app/routes/History.tsx
+++ b/src/app/routes/History.tsx
@@ -1,10 +1,14 @@
 export default function History() {
   return (
-    <div className="card">
-      <div className="section-header">
-        <div className="section-header__title">History</div>
+    <div className="card" data-testid="history-card">
+      <div className="section-header" data-testid="history-header">
+        <div className="section-header__title" data-testid="history-title">
+          History
+        </div>
       </div>
-      <p>Review previously posted events once manual publishing is complete.</p>
+      <p data-testid="history-description">
+        Review previously posted events once manual publishing is complete.
+      </p>
     </div>
   );
 }

--- a/src/app/routes/PendingPosts.tsx
+++ b/src/app/routes/PendingPosts.tsx
@@ -132,32 +132,51 @@ export default function PendingPosts() {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="section-header">
-        <div className="section-header__title">Pending Posts</div>
-        <div className="actions" style={{ display: "flex", gap: "12px" }}>
-          <button className="button" onClick={refresh} disabled={loading || busy}>
+    <div className="space-y-6" data-testid="pending-posts-page">
+      <div className="section-header" data-testid="pending-posts-header">
+        <div className="section-header__title" data-testid="pending-posts-title">
+          Pending Posts
+        </div>
+        <div
+          className="actions"
+          style={{ display: "flex", gap: "12px" }}
+          data-testid="pending-posts-actions"
+        >
+          <button
+            className="button"
+            onClick={refresh}
+            disabled={loading || busy}
+            data-testid="pending-posts-refresh-button"
+          >
             {loading ? "Refreshing…" : "Refresh"}
           </button>
           <button
             className="button"
             disabled={!ids.length || busy}
             onClick={handleMarkPosted}
+            data-testid="pending-posts-mark-posted-button"
           >
             {busy ? "Marking…" : `Mark Posted (${ids.length})`}
           </button>
         </div>
       </div>
 
-      <div className="card" style={{ background: "rgba(59, 130, 246, 0.07)" }}>
-        <p style={{ margin: 0 }}>
+      <div
+        className="card"
+        style={{ background: "rgba(59, 130, 246, 0.07)" }}
+        data-testid="pending-posts-instructions-card"
+      >
+        <p style={{ margin: 0 }} data-testid="pending-posts-instructions-text">
           Copy each draft into Facebook manually. When a show is published, use <strong>Mark Posted</strong>
           to archive it here.
         </p>
       </div>
 
       {toast && (
-        <div className={`toast${toast.kind === "error" ? " toast--error" : ""}`}>
+        <div
+          className={`toast${toast.kind === "error" ? " toast--error" : ""}`}
+          data-testid="pending-posts-toast"
+        >
           {toast.message}
         </div>
       )}
@@ -181,27 +200,43 @@ export default function PendingPosts() {
       })}
 
       {preview && (
-        <div className="card" style={{ whiteSpace: "pre-wrap" }}>
-          <div className="badge" style={{ marginBottom: "12px" }}>
+        <div
+          className="card"
+          style={{ whiteSpace: "pre-wrap" }}
+          data-testid="pending-posts-preview-card"
+        >
+          <div
+            className="badge"
+            style={{ marginBottom: "12px" }}
+            data-testid="pending-posts-preview-badge"
+          >
             Post Preview
           </div>
           {previewEventId && (
-            <div style={{ marginBottom: "12px" }}>
+            <div
+              style={{ marginBottom: "12px" }}
+              data-testid="pending-posts-preview-controls"
+            >
               <button
                 className="button"
                 onClick={() => handlePreview(previewEventId, { force: true })}
                 disabled={!!previewingId}
+                data-testid="pending-posts-regenerate-button"
               >
                 {previewingId === previewEventId ? "Refreshing…" : "Regenerate Preview"}
               </button>
             </div>
           )}
           {previewGenre && (
-            <div className="badge" style={{ marginBottom: "12px" }}>
+            <div
+              className="badge"
+              style={{ marginBottom: "12px" }}
+              data-testid="pending-posts-preview-genre"
+            >
               Genre: {previewGenre}
             </div>
           )}
-          {preview}
+          <div data-testid="pending-posts-preview-content">{preview}</div>
         </div>
       )}
     </div>
@@ -229,14 +264,27 @@ function BucketSection({
   previewEventId,
   genresById,
 }: BucketSectionProps) {
+  const slug = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    || "bucket";
   return (
-    <section className="card">
-      <div className="section-header" style={{ marginBottom: "12px" }}>
-        <div className="section-header__title" style={{ fontSize: "18px" }}>
-          {label} <span className="badge">{rows.length}</span>
+    <section className="card" data-testid={`pending-posts-bucket-${slug}`}>
+      <div
+        className="section-header"
+        style={{ marginBottom: "12px" }}
+        data-testid={`pending-posts-bucket-header-${slug}`}
+      >
+        <div
+          className="section-header__title"
+          style={{ fontSize: "18px" }}
+          data-testid={`pending-posts-bucket-title-${slug}`}
+        >
+          {label} <span className="badge" data-testid={`pending-posts-bucket-count-${slug}`}>{rows.length}</span>
         </div>
       </div>
-      <div className="pending-grid">
+      <div className="pending-grid" data-testid={`pending-posts-bucket-grid-${slug}`}>
         {rows.map(({ days_until, event }) => {
           const checked = !!selected[event.id];
           const eventTime = new Date(event.start_local ?? event.start_utc);
@@ -245,23 +293,31 @@ function BucketSection({
           const isCurrentPreview = previewEventId === event.id;
           const genre = genresById[event.id];
           return (
-            <div key={event.id} className="pending-card">
+            <div
+              key={event.id}
+              className="pending-card"
+              data-testid={`pending-card-${event.id}`}
+            >
               <input
                 type="checkbox"
                 checked={checked}
                 onChange={(e) =>
                   setSelected((prev) => ({ ...prev, [event.id]: e.target.checked }))
                 }
+                data-testid={`pending-card-checkbox-${event.id}`}
               />
-              <div style={{ flex: 1 }}>
-                <div className="pending-card__title">
+              <div style={{ flex: 1 }} data-testid={`pending-card-body-${event.id}`}>
+                <div className="pending-card__title" data-testid={`pending-card-title-${event.id}`}>
                   {event.artists[0] ?? "TBA"} — {event.venue_name ?? ""}
                 </div>
-                <div className="pending-card__meta">
+                <div className="pending-card__meta" data-testid={`pending-card-meta-${event.id}`}>
                   {formatted} • {days_until} day{days_until === 1 ? "" : "s"} out
                 </div>
                 {genre && (
-                  <div className="pending-card__meta">
+                  <div
+                    className="pending-card__meta"
+                    data-testid={`pending-card-genre-${event.id}`}
+                  >
                     Genre: {genre}
                   </div>
                 )}
@@ -272,6 +328,7 @@ function BucketSection({
                   href={event.ticket_url}
                   target="_blank"
                   rel="noreferrer"
+                  data-testid={`pending-card-tickets-${event.id}`}
                 >
                   Tickets
                 </a>
@@ -280,6 +337,7 @@ function BucketSection({
                 className="button"
                 onClick={() => onPreview(event.id)}
                 disabled={isPreviewing}
+                data-testid={`pending-card-preview-button-${event.id}`}
               >
                 {isPreviewing
                   ? "Previewing…"

--- a/src/app/routes/Settings.tsx
+++ b/src/app/routes/Settings.tsx
@@ -121,32 +121,51 @@ export default function Settings() {
   }, []);
 
   return (
-    <div className="space-y-6">
-      <div className="section-header">
-        <div className="section-header__title">Settings</div>
-        <div className="actions" style={{ display: "flex", gap: "12px" }}>
-          <button className="button" onClick={reset} disabled={isDisabled}>
+    <div className="space-y-6" data-testid="settings-page">
+      <div className="section-header" data-testid="settings-header">
+        <div className="section-header__title" data-testid="settings-title">
+          Settings
+        </div>
+        <div
+          className="actions"
+          style={{ display: "flex", gap: "12px" }}
+          data-testid="settings-header-actions"
+        >
+          <button
+            className="button"
+            onClick={reset}
+            disabled={isDisabled}
+            data-testid="settings-reset-button"
+          >
             Reset to Defaults
           </button>
           <button
             className="button"
             onClick={save}
             disabled={isDisabled || !dirty}
+            data-testid="settings-save-button"
           >
             Save Changes
           </button>
         </div>
       </div>
 
-      <div className="card form-section">
-        <header className="form-section__header">
-          <h2>AI Composer</h2>
-          <p>Configure how the desktop app talks to your OpenAI-compatible server.</p>
+      <div className="card form-section" data-testid="settings-ai-composer-section">
+        <header className="form-section__header" data-testid="settings-ai-composer-header">
+          <h2 data-testid="settings-ai-composer-title">AI Composer</h2>
+          <p data-testid="settings-ai-composer-description">
+            Configure how the desktop app talks to your OpenAI-compatible server.
+          </p>
         </header>
-        <div className="form-grid">
-          <label className="form-field">
-            <span className="form-field__label">OpenAI-compatible Endpoint</span>
-            <span className="form-field__description">
+        <div className="form-grid" data-testid="settings-ai-composer-grid">
+          <label className="form-field" data-testid="settings-endpoint-field">
+            <span className="form-field__label" data-testid="settings-endpoint-label">
+              OpenAI-compatible Endpoint
+            </span>
+            <span
+              className="form-field__description"
+              data-testid="settings-endpoint-description"
+            >
               Defaults to {DEFAULT_LLM_ENDPOINT}. Update this to point at your server’s `/v1` base URL.
             </span>
             <input
@@ -156,21 +175,28 @@ export default function Settings() {
               onChange={(event) => update("llmEndpoint", event.target.value)}
               placeholder={DEFAULT_LLM_ENDPOINT}
               disabled={isDisabled}
+              data-testid="settings-endpoint-input"
             />
           </label>
 
-          <label className="form-field">
-            <span className="form-field__label">Model</span>
-            <span className="form-field__description">
+          <label className="form-field" data-testid="settings-model-field">
+            <span className="form-field__label" data-testid="settings-model-label">
+              Model
+            </span>
+            <span className="form-field__description" data-testid="settings-model-description">
               Pick from models reported by the API’s `/models` endpoint.
             </span>
-            <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
+            <div
+              style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}
+              data-testid="settings-model-controls"
+            >
               <select
                 className="input"
                 value={settings.llmModel || ""}
                 onChange={(event) => update("llmModel", event.target.value)}
                 disabled={isDisabled || modelsBusy || !modelSelectOptions.length}
                 style={{ flex: "1 1 220px", minWidth: "160px" }}
+                data-testid="settings-model-select"
               >
                 <option value="" disabled>
                   {modelsBusy
@@ -180,7 +206,7 @@ export default function Settings() {
                     : "No models available"}
                 </option>
                 {modelSelectOptions.map((value) => (
-                  <option key={value} value={value}>
+                  <option key={value} value={value} data-testid={`settings-model-option-${value}`}>
                     {value}
                   </option>
                 ))}
@@ -190,12 +216,17 @@ export default function Settings() {
                 type="button"
                 onClick={handleReloadModels}
                 disabled={modelsBusy || isDisabled}
+                data-testid="settings-reload-models-button"
               >
                 {modelsBusy ? "Refreshing…" : "Reload Models"}
               </button>
             </div>
             {modelsError && (
-              <div className="form-field__description" style={{ color: "#c00" }}>
+              <div
+                className="form-field__description"
+                style={{ color: "#c00" }}
+                data-testid="settings-model-error"
+              >
                 {modelsError}
               </div>
             )}
@@ -203,38 +234,52 @@ export default function Settings() {
         </div>
       </div>
 
-      <div className="card form-section">
-        <header className="form-section__header">
-          <h2>Posting Workflow</h2>
-          <p>Drafts are generated here and posted to Facebook manually.</p>
+      <div className="card form-section" data-testid="settings-posting-section">
+        <header className="form-section__header" data-testid="settings-posting-header">
+          <h2 data-testid="settings-posting-title">Posting Workflow</h2>
+          <p data-testid="settings-posting-description">
+            Drafts are generated here and posted to Facebook manually.
+          </p>
         </header>
 
-        <div className="form-grid">
-          <label className="checkbox-field">
+        <div className="form-grid" data-testid="settings-posting-grid">
+          <label className="checkbox-field" data-testid="settings-notify-field">
             <input
               type="checkbox"
               checked={settings.notifyOnPost}
               onChange={(event) => update("notifyOnPost", event.target.checked)}
               disabled={isDisabled}
+              data-testid="settings-notify-checkbox"
             />
-            <div>
-              <span className="form-field__label">Show notification after marking posted</span>
-              <span className="form-field__description">
+            <div data-testid="settings-notify-text">
+              <span className="form-field__label" data-testid="settings-notify-label">
+                Show notification after marking posted
+              </span>
+              <span
+                className="form-field__description"
+                data-testid="settings-notify-description"
+              >
                 Keep the manual workflow visible with a toast after events are marked complete.
               </span>
             </div>
           </label>
 
-          <label className="checkbox-field">
+          <label className="checkbox-field" data-testid="settings-auto-preview-field">
             <input
               type="checkbox"
               checked={settings.autoOpenPreview}
               onChange={(event) => update("autoOpenPreview", event.target.checked)}
               disabled={isDisabled}
+              data-testid="settings-auto-preview-checkbox"
             />
-            <div>
-              <span className="form-field__label">Auto-open post preview</span>
-              <span className="form-field__description">
+            <div data-testid="settings-auto-preview-text">
+              <span className="form-field__label" data-testid="settings-auto-preview-label">
+                Auto-open post preview
+              </span>
+              <span
+                className="form-field__description"
+                data-testid="settings-auto-preview-description"
+              >
                 When enabled, the Pending Posts screen shows the AI draft after a scrape finishes.
               </span>
             </div>
@@ -242,15 +287,22 @@ export default function Settings() {
         </div>
       </div>
 
-      <div className="card form-section">
-        <header className="form-section__header">
-          <h2>Storage</h2>
-          <p>Control where exports, logs, and the SQLite database live.</p>
+      <div className="card form-section" data-testid="settings-storage-section">
+        <header className="form-section__header" data-testid="settings-storage-header">
+          <h2 data-testid="settings-storage-title">Storage</h2>
+          <p data-testid="settings-storage-description">
+            Control where exports, logs, and the SQLite database live.
+          </p>
         </header>
-        <div className="form-grid">
-          <label className="form-field">
-            <span className="form-field__label">Data Directory</span>
-            <span className="form-field__description">
+        <div className="form-grid" data-testid="settings-storage-grid">
+          <label className="form-field" data-testid="settings-data-directory-field">
+            <span className="form-field__label" data-testid="settings-data-directory-label">
+              Data Directory
+            </span>
+            <span
+              className="form-field__description"
+              data-testid="settings-data-directory-description"
+            >
               Set the folder where the scraper writes the SQLite database and debug output.
             </span>
             <input
@@ -259,24 +311,29 @@ export default function Settings() {
               value={settings.dataDirectory}
               onChange={(event) => update("dataDirectory", event.target.value)}
               disabled={isDisabled}
+              data-testid="settings-data-directory-input"
             />
           </label>
         </div>
       </div>
 
-      <div className="card form-section">
-        <header className="form-section__header">
-          <h2>Quick Reference</h2>
-          <p>All settings are stored locally on this machine.</p>
+      <div className="card form-section" data-testid="settings-quick-reference-section">
+        <header className="form-section__header" data-testid="settings-quick-reference-header">
+          <h2 data-testid="settings-quick-reference-title">Quick Reference</h2>
+          <p data-testid="settings-quick-reference-description">
+            All settings are stored locally on this machine.
+          </p>
         </header>
-        <ul className="summary-list">
-          <li>
+        <ul className="summary-list" data-testid="settings-quick-reference-list">
+          <li data-testid="settings-quick-reference-save">
             <strong>Save</strong> commits changes to browser storage and updates the Pending Posts behavior.
           </li>
-          <li>
+          <li data-testid="settings-quick-reference-reset">
             <strong>Reset</strong> restores defaults (model, directories, toggles) without touching scraped data.
           </li>
-          <li>{savedAt ? `Last saved ${savedAt}.` : "Settings have not been saved yet."}</li>
+          <li data-testid="settings-quick-reference-saved-at">
+            {savedAt ? `Last saved ${savedAt}.` : "Settings have not been saved yet."}
+          </li>
         </ul>
       </div>
     </div>

--- a/src/app/routes/Venues.tsx
+++ b/src/app/routes/Venues.tsx
@@ -155,31 +155,50 @@ export default function Venues() {
   }, [venues]);
 
   return (
-    <div className="space-y-6">
-      <div className="section-header">
-        <div className="section-header__title">Venues</div>
-        <div className="actions" style={{ display: "flex", gap: "12px" }}>
-          <button className="button" onClick={loadVenues} disabled={loading || bulkBusy}>
+    <div className="space-y-6" data-testid="venues-page">
+      <div className="section-header" data-testid="venues-header">
+        <div className="section-header__title" data-testid="venues-title">
+          Venues
+        </div>
+        <div
+          className="actions"
+          style={{ display: "flex", gap: "12px" }}
+          data-testid="venues-actions"
+        >
+          <button
+            className="button"
+            onClick={loadVenues}
+            disabled={loading || bulkBusy}
+            data-testid="venues-refresh-button"
+          >
             {loading ? "Refreshing…" : "Refresh"}
           </button>
-          <button className="button" onClick={handleScrapeAll} disabled={bulkBusy || loading}>
+          <button
+            className="button"
+            onClick={handleScrapeAll}
+            disabled={bulkBusy || loading}
+            data-testid="venues-scrape-all-button"
+          >
             {bulkBusy ? "Scraping…" : "Scrape All"}
           </button>
         </div>
       </div>
 
       {toast && (
-        <div className={`toast${toast.kind === "error" ? " toast--error" : ""}`}>
+        <div
+          className={`toast${toast.kind === "error" ? " toast--error" : ""}`}
+          data-testid="venues-toast"
+        >
           {toast.message}
         </div>
       )}
 
       {loading && !venues.length ? (
-        <div className="card">Loading venues…</div>
+        <div className="card" data-testid="venues-loading">Loading venues…</div>
       ) : !sortedVenues.length ? (
-        <div className="card">No venues configured yet.</div>
+        <div className="card" data-testid="venues-empty">No venues configured yet.</div>
       ) : (
-        <div className="pending-grid">
+        <div className="pending-grid" data-testid="venues-grid">
           {sortedVenues.map((venue) => {
             const state = states[venue.id] || { running: false };
             return (
@@ -207,14 +226,34 @@ type VenueCardProps = {
 
 function VenueCard({ venue, state, disabled, onScrape }: VenueCardProps) {
   const busy = state.running || disabled;
+  const testIdSlug = venue.id
+    ? venue.id.toString().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "")
+    : "venue";
   return (
-    <section className="card" style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-        <div>
-          <div className="pending-card__title" style={{ fontSize: "18px" }}>
+    <section
+      className="card"
+      style={{ display: "flex", flexDirection: "column", gap: "12px" }}
+      data-testid={`venue-card-${testIdSlug}`}
+    >
+      <div
+        style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}
+        data-testid={`venue-card-header-${testIdSlug}`}
+      >
+        <div data-testid={`venue-card-details-${testIdSlug}`}>
+          <div
+            className="pending-card__title"
+            style={{ fontSize: "18px" }}
+            data-testid={`venue-card-name-${testIdSlug}`}
+          >
             {venue.name}
           </div>
-          <a href={venue.url} className="pending-card__meta" target="_blank" rel="noreferrer">
+          <a
+            href={venue.url}
+            className="pending-card__meta"
+            target="_blank"
+            rel="noreferrer"
+            data-testid={`venue-card-url-${testIdSlug}`}
+          >
             {venue.url}
           </a>
         </div>
@@ -223,14 +262,27 @@ function VenueCard({ venue, state, disabled, onScrape }: VenueCardProps) {
           disabled={busy}
           onClick={() => onScrape(venue.id)}
           style={{ minWidth: "120px", justifyContent: "center" }}
+          data-testid={`venue-card-scrape-button-${testIdSlug}`}
         >
           {state.running ? "Scraping…" : "Run Scrape"}
         </button>
       </div>
-      <div className="pending-card__meta" style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
-        <span>Last run: {state.lastRun ?? "—"}</span>
-        <span>Events scraped: {typeof state.lastCount === "number" ? state.lastCount : "—"}</span>
-        {state.error && <span style={{ color: "#b91c1c" }}>{state.error}</span>}
+      <div
+        className="pending-card__meta"
+        style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}
+        data-testid={`venue-card-meta-${testIdSlug}`}
+      >
+        <span data-testid={`venue-card-last-run-${testIdSlug}`}>
+          Last run: {state.lastRun ?? "—"}
+        </span>
+        <span data-testid={`venue-card-last-count-${testIdSlug}`}>
+          Events scraped: {typeof state.lastCount === "number" ? state.lastCount : "—"}
+        </span>
+        {state.error && (
+          <span style={{ color: "#b91c1c" }} data-testid={`venue-card-error-${testIdSlug}`}>
+            {state.error}
+          </span>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add data-testid attributes across the app shell for navigation, sidebar, and content regions
- expose stable data-testid hooks on dashboard, history, and venues workflows for UI automation
- annotate pending posts and settings interactions with detailed test ids for browser-driven tests

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e439d3620883269f165919bfb39974