### PR TITLE
Fix Tauri capability permission configuration

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,7 +4,6 @@
   "description": "Capability for the main window",
   "windows": ["main"],
   "permissions": [
-    "core:default",
-    "opener:default"
+    "core:default"
   ]
 }


### PR DESCRIPTION
## Summary
- remove the undefined `opener:default` permission from the default capability to match the available core permissions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e45db7b578832686687e556bec560c